### PR TITLE
Feature Updated Devise Views with Bootstrap

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,22 @@
-<h2>Resend confirmation instructions</h2>
+<h2 class="text-center mb-4">Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "w-50 mx-auto" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  <!-- Email Field -->
+  <div class="mb-3">
+    <%= f.label :email, class: "form-label" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), required: true, class: "form-control", placeholder: "Enter your email address" %>
+    <small class="text-danger">Email is a required field</small>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+  <!-- Submit Button -->
+  <div class="mb-3 text-center">
+    <%= f.submit "Resend confirmation instructions", class: "btn btn-primary px-4" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<!-- Centered Links -->
+<div class="text-center">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,33 @@
-<h2>Change your password</h2>
+<h2 class="text-center mb-4">Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "w-50 mx-auto" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
+  <!-- New Password -->
+  <div class="mb-3">
+    <%= f.label :password, "New password", class: "form-label" %>
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <small class="text-muted d-block">(<%= @minimum_password_length %> characters minimum)</small>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", required: true, placeholder: "Enter new password", class: "form-control" %>
+    <small class="text-danger">Password is a required field</small>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <!-- Confirm New Password -->
+  <div class="mb-3">
+    <%= f.label :password_confirmation, "Confirm new password", class: "form-label" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, placeholder: "Re-enter new password", class: "form-control" %>
+    <small class="text-danger">Password confirmation is a required field</small>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
+  <!-- Submit Button -->
+  <div class="mb-3 text-center">
+    <%= f.submit "Change my password", class: "btn btn-primary px-4" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<!-- Centered Links -->
+<div class="text-center">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,12 +1,12 @@
 <h2 class="text-center mb-4">Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "w-50 mx-auto" }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "w-25 mx-auto form-container", style: "border: 2px solid #808080; padding: 15px; border-radius: 5px;" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <!-- Email -->
   <div class="mb-3">
     <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #ffffff;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 
@@ -14,8 +14,10 @@
   <div class="mb-3 text-center">
     <%= f.submit "Send me reset password instructions", class: "btn btn-secondary text-white px-4" %>
   </div>
+
 <% end %>
 
+<!-- Centered Links (Inside the border) -->
 <div class="text-center">
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,18 +2,18 @@
   
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <h2 class="text-center mb-4">Forgot your password?</h2>
+  <h2 class="text-center mb-4">Forgot Your Password?</h2>
 
   <!-- Email -->
   <div class="mb-3">
-    <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+    <p>Enter your email address and we will send you instructions to reset your password.</p>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email address*", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 
   <!-- Submit Button -->
   <div class="mb-3 text-center">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-secondary text-white px-4" %>
+    <%= f.submit "Continue", class: "btn btn-secondary text-white px-4" %>
   </div>
 
   <!-- Centered Links (Inside the border) -->

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Forgot your password?</h2>
+<h2 class="text-center mb-4">Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "w-50 mx-auto" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <!-- Email -->
+  <div class="mb-3">
+    <%= f.label :email, class: "form-label" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+    <small class="text-danger">Email is a required field</small>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+  <!-- Submit Button -->
+  <div class="mb-3 text-center">
+    <%= f.submit "Send me reset password instructions", class: "btn btn-primary px-4" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="text-center">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,7 +12,7 @@
 
   <!-- Submit Button -->
   <div class="mb-3 text-center">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-primary px-4" %>
+    <%= f.submit "Send me reset password instructions", class: "btn btn-secondary text-white px-4" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -7,7 +7,7 @@
   <!-- Email -->
   <div class="mb-3">
     <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #ffffff;" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,8 @@
-<h2 class="text-center mb-4">Forgot your password?</h2>
-
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "w-25 mx-auto form-container", style: "border: 2px solid #808080; padding: 15px; border-radius: 5px;" }) do |f| %>
+  
   <%= render "devise/shared/error_messages", resource: resource %>
+
+  <h2 class="text-center mb-4">Forgot your password?</h2>
 
   <!-- Email -->
   <div class="mb-3">
@@ -15,9 +16,9 @@
     <%= f.submit "Send me reset password instructions", class: "btn btn-secondary text-white px-4" %>
   </div>
 
-<% end %>
+  <!-- Centered Links (Inside the border) -->
+  <div class="text-center">
+    <%= render "devise/shared/links" %>
+  </div>
 
-<!-- Centered Links (Inside the border) -->
-<div class="text-center">
-  <%= render "devise/shared/links" %>
-</div>
+<% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,101 +1,95 @@
-<h2 class="text-center mb-4">Edit Account</h2>
+<h2 class="text-center mb-4">Edit Profile</h2>
 
 <div class="d-flex justify-content-center">
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'w-50' }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "w-50 form-container", style: "border: 2px solid #808080; padding: 20px; border-radius: 5px;" }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
 
-    <!-- First Name -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :first_name, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">First name is a required field</small>
+    <!-- First and Last Name on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <%= f.label :first_name, class: "form-label" %>
+        <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">First name is a required field</small>
+      </div>
+      <div class="col-md-6">
+        <%= f.label :last_name, class: "form-label" %>
+        <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Last name is a required field</small>
+      </div>
     </div>
-    
-    <!-- Last Name -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :last_name, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Last name is a required field</small>
+
+    <!-- Email and Phone Number on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Email is a required field</small>
+      </div>
+      <div class="col-md-6">
+        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Phone number is a required field</small>
+      </div>
     </div>
-    
-    <!-- Email -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :email, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Email is a required field</small>
-    </div>  
 
     <!-- Current Password -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :current_password, class: "form-label" %> <i>(we need your current password to confirm your changes)</i><br />
+    <div class="mb-3">
+      <%= f.label :current_password, class: "form-label" %>
+      <i>(We need your current password to confirm your changes)</i>
       <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control", style: "background-color: #f0f0f0;" %>
     </div>
 
-    <!-- Password -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :password, "New Password", class: "form-label" %> <i>(leave blank if you don't want to change it)</i><br />
-      <%= f.password_field :password, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
-      <% if @minimum_password_length %>
-        <br />
-        <em><%= @minimum_password_length %> characters minimum</em>
-      <% end %>
+    <!-- Password and Confirmation on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <%= f.label :password, "New Password", class: "form-label" %>
+        <i>(Leave blank if you don't want to change it)</i>
+        <%= f.password_field :password, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
+        <% if @minimum_password_length %>
+          <em><%= @minimum_password_length %> characters minimum</em>
+        <% end %>
+      </div>
+      <div class="col-md-6">
+        <%= f.label :password_confirmation, "New Password Confirmation", class: "form-label" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
+      </div>
     </div>
 
-    <!-- Password Confirmation -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :password_confirmation, "New Password Confirmation", class: "form-label" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
+    <!-- Gender, Age Range, and Ethnicity on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-4">
+        <%= f.label :gender, class: "form-label" %>
+        <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Gender is a required field</small>
+      </div>
+      <div class="col-md-4">
+        <%= f.label :age_range, class: "form-label" %>
+        <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Age range is a required field</small>
+      </div>
+      <div class="col-md-4">
+        <%= f.label :ethnicity, class: "form-label" %>
+        <%= f.select :ethnicity, options_for_select([
+          ["White", "White"],
+          ["Black or African American", "Black or African American"],
+          ["Asian", "Asian"],
+          ["American Indian or Alaska Native", "American Indian or Alaska Native"],
+          ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
+          ["Hispanic or Latino", "Hispanic or Latino"],
+          ["Other", "Other"],
+          ["Prefer not to say", "Prefer not to say"]
+        ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Ethnicity is a required field</small>
+      </div>
     </div>
 
-    <!-- Phone Number -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :phone_number, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Phone number is a required field</small>
-    </div>
-
-    <!-- Gender -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :gender, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Gender is a required field</small>
-    </div>
-
-    <!-- Age Range -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :age_range, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Age range is a required field</small>
-    </div>
-
-    <!-- Ethnicity -->
-    <div class="mb-3 border p-3 rounded">
-      <%= f.label :ethnicity, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.select :ethnicity, options_for_select([
-        ["White", "White"],
-        ["Black or African American", "Black or African American"],
-        ["Asian", "Asian"],
-        ["American Indian or Alaska Native", "American Indian or Alaska Native"],
-        ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
-        ["Hispanic or Latino", "Hispanic or Latino"],
-        ["Other", "Other"],
-        ["Prefer not to say", "Prefer not to say"]
-      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Ethnicity is a required field</small>
-    </div>
-
+    <!-- Submit Button -->
     <div class="mb-3 text-center">
-      <%= f.submit "Update", class: "btn btn-secondary text-white px-4" %>
+      <%= f.submit "Save", class: "btn btn-secondary text-white px-4" %>
     </div>
   <% end %>
 </div>
+<div class="mt-3 text-center">
+    <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger btn-md" %>
+  </div>
 
-<div class="border border-secondary p-3 ms-3 d-inline-block">
-  
-  <div class="mt-3">
-    <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-warning btn-md" %>
-  </div>
-  <div class="mt-2">
-    <%= link_to "Back", :back, class: "btn btn-link text-muted btn-md" %>
-  </div>
-</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,13 +7,13 @@
     <!-- First and Last Name on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-6">
-        <%= f.label :first_name, class: "form-label" %>
-        <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <%= f.label :first_name, class: "form-label" %><span style="color: red;">*</span>
+        <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">First name is a required field</small>
       </div>
       <div class="col-md-6">
-        <%= f.label :last_name, class: "form-label" %>
-        <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <%= f.label :last_name, class: "form-label" %><span style="color: red;">*</span>
+        <%= f.text_field :last_name, autocomplete: "last_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Last name is a required field</small>
       </div>
     </div>
@@ -21,12 +21,12 @@
     <!-- Email and Phone Number on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-6">
-        <%= f.label :email, class: "form-label" %>
-        <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <%= f.label :email, class: "form-label" %><span style="color: red;">*</span>
+        <%= f.email_field :email, autocomplete: "email", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Email is a required field</small>
       </div>
       <div class="col-md-6">
-        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.label :phone_number, class: "form-label" %><span style="color: red;">*</span>
         <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Phone number is a required field</small>
       </div>
@@ -34,8 +34,8 @@
 
     <!-- Current Password -->
     <div class="mb-3">
-      <%= f.label :current_password, class: "form-label" %>
-      <i>(We need your current password to confirm your changes)</i>
+      <%= f.label :current_password, class: "form-label" %><span style="color: red;">*</span>
+      <i class="text-danger"><small>(We need your current password to confirm your changes)</small></i>
       <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control", style: "background-color: #f0f0f0;" %>
     </div>
 
@@ -43,7 +43,7 @@
     <div class="row mb-3">
       <div class="col-md-6">
         <%= f.label :password, "New Password", class: "form-label" %>
-        <i>(Leave blank if you don't want to change it)</i>
+        <i><small>(Leave blank if you don't want to change it)</small></i>
         <%= f.password_field :password, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
         <% if @minimum_password_length %>
           <em><%= @minimum_password_length %> characters minimum</em>
@@ -58,17 +58,17 @@
     <!-- Gender, Age Range, and Ethnicity on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-4">
-        <%= f.label :gender, class: "form-label" %>
+        <%= f.label :gender, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Gender is a required field</small>
       </div>
       <div class="col-md-4">
-        <%= f.label :age_range, class: "form-label" %>
+        <%= f.label :age_range, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Age range is a required field</small>
       </div>
       <div class="col-md-4">
-        <%= f.label :ethnicity, class: "form-label" %>
+        <%= f.label :ethnicity, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :ethnicity, options_for_select([
           ["White", "White"],
           ["Black or African American", "Black or African American"],

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,95 +1,101 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2 class="text-center mb-4">Edit Account</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="d-flex justify-content-center">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'w-50' }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <!-- First Name -->
-  <div class="field">
-    <%= f.label :first_name %> <span style="color: red;">*</span><br />
-    <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true %>
-    <small style="color: red;">First name is a required field</small>
-  </div>
+    <!-- First Name -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :first_name, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control" %>
+      <small class="text-danger">First name is a required field</small>
+    </div>
+    
+    <!-- Last Name -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :last_name, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control" %>
+      <small class="text-danger">Last name is a required field</small>
+    </div>
+    
+    <!-- Email -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :email, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+      <small class="text-danger">Email is a required field</small>
+    </div>  
+
+    <!-- Current Password -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :current_password, class: "form-label" %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+    </div>
+
+    <!-- Password -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :password, "New Password", class: "form-label" %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+      <% if @minimum_password_length %>
+        <br />
+        <em><%= @minimum_password_length %> characters minimum</em>
+      <% end %>
+    </div>
+
+    <!-- Password Confirmation -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :password_confirmation, "New Password Confirmation", class: "form-label" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+    </div>
+
+    <!-- Phone Number -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :phone_number, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control" %>
+      <small class="text-danger">Phone number is a required field</small>
+    </div>
+
+    <!-- Gender -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :gender, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select" %>
+      <small class="text-danger">Gender is a required field</small>
+    </div>
+
+    <!-- Age Range -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :age_range, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select" %>
+      <small class="text-danger">Age range is a required field</small>
+    </div>
+
+    <!-- Ethnicity -->
+    <div class="mb-3 border p-3 rounded">
+      <%= f.label :ethnicity, class: "form-label" %> <span style="color: red;">*</span><br />
+      <%= f.select :ethnicity, options_for_select([
+        ["White", "White"],
+        ["Black or African American", "Black or African American"],
+        ["Asian", "Asian"],
+        ["American Indian or Alaska Native", "American Indian or Alaska Native"],
+        ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
+        ["Hispanic or Latino", "Hispanic or Latino"],
+        ["Other", "Other"],
+        ["Prefer not to say", "Prefer not to say"]
+      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select" %>
+      <small class="text-danger">Ethnicity is a required field</small>
+    </div>
+
+    <div class="mb-3 text-center">
+      <%= f.submit "Update", class: "btn btn-secondary text-white px-4" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="border border-secondary p-3 ms-3 d-inline-block">
   
-  <!-- Last Name -->
-  <div class="field">
-    <%= f.label :last_name %> <span style="color: red;">*</span><br />
-    <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true %>
-    <small style="color: red;">Last name is a required field</small>
+  <div class="mt-3">
+    <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-warning btn-md" %>
   </div>
-  
-  <!-- Email -->
-  <div class="field">
-    <%= f.label :email %> <span style="color: red;">*</span><br />
-    <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true %>
-    <small style="color: red;">Email is a required field</small>
-  </div>  
-
-  <!-- Current Password -->
-<div class="field">
-  <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-  <%= f.password_field :current_password, autocomplete: "current-password" %>
-</div>
-
-  <!-- Password -->
-  <div class="field">
-    <%= f.label :password, "New Password" %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <div class="mt-2">
+    <%= link_to "Back", :back, class: "btn btn-link text-muted btn-md" %>
   </div>
-
-  <!-- Password Confirmation -->
-  <div class="field">
-    <%= f.label :password_confirmation, "New Password Confirmation" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <!-- Phone Number -->
-<div class="field">
-  <%= f.label :phone_number %> <span style="color: red;">*</span><br />
-  <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true %>
-  <small style="color: red;">Phone number is a required field</small>
 </div>
-
-<!-- Gender -->
-<div class="field">
-  <%= f.label :gender %> <span style="color: red;">*</span><br />
-  <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true %>
-  <small style="color: red;">Gender is a required field</small>
-</div>
-
-<!-- Age Range -->
-<div class="field">
-  <%= f.label :age_range %> <span style="color: red;">*</span><br />
-  <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true %>
-  <small style="color: red;">Age range is a required field</small>
-</div>
-
-<!-- Ethnicity -->
-<div class="field">
-  <%= f.label :ethnicity %> <span style="color: red;">*</span><br />
-  <%= f.select :ethnicity, options_for_select([
-    ["White", "White"],
-    ["Black or African American", "Black or African American"],
-    ["Asian", "Asian"],
-    ["American Indian or Alaska Native", "American Indian or Alaska Native"],
-    ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
-    ["Hispanic or Latino", "Hispanic or Latino"],
-    ["Other", "Other"],
-    ["Prefer not to say", "Prefer not to say"]
-  ]), { prompt: "Select Ethnicity" }, required: true %>
-  <small style="color: red;">Ethnicity is a required field</small>
-</div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,34 +7,34 @@
     <!-- First Name -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :first_name, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control" %>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">First name is a required field</small>
     </div>
     
     <!-- Last Name -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :last_name, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control" %>
+      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Last name is a required field</small>
     </div>
     
     <!-- Email -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :email, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Email is a required field</small>
     </div>  
 
     <!-- Current Password -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :current_password, class: "form-label" %> <i>(we need your current password to confirm your changes)</i><br />
-      <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control", style: "background-color: #f0f0f0;" %>
     </div>
 
     <!-- Password -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :password, "New Password", class: "form-label" %> <i>(leave blank if you don't want to change it)</i><br />
-      <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
       <% if @minimum_password_length %>
         <br />
         <em><%= @minimum_password_length %> characters minimum</em>
@@ -44,27 +44,27 @@
     <!-- Password Confirmation -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :password_confirmation, "New Password Confirmation", class: "form-label" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", style: "background-color: #f0f0f0;" %>
     </div>
 
     <!-- Phone Number -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :phone_number, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control" %>
+      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Phone number is a required field</small>
     </div>
 
     <!-- Gender -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :gender, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select" %>
+      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Gender is a required field</small>
     </div>
 
     <!-- Age Range -->
     <div class="mb-3 border p-3 rounded">
       <%= f.label :age_range, class: "form-label" %> <span style="color: red;">*</span><br />
-      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select" %>
+      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Age range is a required field</small>
     </div>
 
@@ -80,7 +80,7 @@
         ["Hispanic or Latino", "Hispanic or Latino"],
         ["Other", "Other"],
         ["Prefer not to say", "Prefer not to say"]
-      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select" %>
+      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Ethnicity is a required field</small>
     </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,26 +4,33 @@
 
     <h2 class="text-center mb-4">Sign up</h2>
 
-    <!-- First Name -->
-    <div class="mb-3">
-      <%= f.label :first_name, class: "form-label" %>
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">First name is a required field</small>
+    <!-- First and Last Name on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <%= f.label :first_name, class: "form-label" %>
+        <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">First name is a required field</small>
+      </div>
+      <div class="col-md-6">
+        <%= f.label :last_name, class: "form-label" %>
+        <%= f.text_field :last_name, autocomplete: "last_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Last name is a required field</small>
+      </div>
     </div>
-    
-    <!-- Last Name -->
-    <div class="mb-3">
-      <%= f.label :last_name, class: "form-label" %>
-      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Last name is a required field</small>
+
+    <!-- Email and Phone Number on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <%= f.label :email, class: "form-label" %>
+        <%= f.email_field :email, autocomplete: "email", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Email is a required field</small>
+      </div>
+      <div class="col-md-6">
+        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Phone number is a required field</small>
+      </div>
     </div>
-    
-    <!-- Email -->
-    <div class="mb-3">
-      <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Email is a required field</small>
-    </div>  
 
     <!-- Password -->
     <div class="mb-3">
@@ -42,41 +49,32 @@
       <small class="text-danger">Password confirmation is a required field</small>
     </div>
 
-    <!-- Phone Number -->
-    <div class="mb-3">
-      <%= f.label :phone_number, class: "form-label" %>
-      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Phone number is a required field</small>
-    </div>
-
-    <!-- Gender -->
-    <div class="mb-3">
-      <%= f.label :gender, class: "form-label" %>
-      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Gender is a required field</small>
-    </div>
-
-    <!-- Age Range -->
-    <div class="mb-3">
-      <%= f.label :age_range, class: "form-label" %>
-      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Age range is a required field</small>
-    </div>
-
-    <!-- Ethnicity -->
-    <div class="mb-3">
-      <%= f.label :ethnicity, class: "form-label" %>
-      <%= f.select :ethnicity, options_for_select([
-        ["White", "White"],
-        ["Black or African American", "Black or African American"],
-        ["Asian", "Asian"],
-        ["American Indian or Alaska Native", "American Indian or Alaska Native"],
-        ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
-        ["Hispanic or Latino", "Hispanic or Latino"],
-        ["Other", "Other"],
-        ["Prefer not to say", "Prefer not to say"]
-      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
-      <small class="text-danger">Ethnicity is a required field</small>
+    <!-- Gender, Age Range, and Ethnicity on the Same Line -->
+    <div class="row mb-3">
+      <div class="col-md-4">
+        <%= f.label :gender, class: "form-label" %>
+        <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Gender is a required field</small>
+      </div>
+      <div class="col-md-4">
+        <%= f.label :age_range, class: "form-label" %>
+        <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Age range is a required field</small>
+      </div>
+      <div class="col-md-4">
+        <%= f.label :ethnicity, class: "form-label" %>
+        <%= f.select :ethnicity, options_for_select([
+          ["White", "White"],
+          ["Black or African American", "Black or African American"],
+          ["Asian", "Asian"],
+          ["American Indian or Alaska Native", "American Indian or Alaska Native"],
+          ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
+          ["Hispanic or Latino", "Hispanic or Latino"],
+          ["Other", "Other"],
+          ["Prefer not to say", "Prefer not to say"]
+        ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
+        <small class="text-danger">Ethnicity is a required field</small>
+      </div>
     </div>
 
     <!-- Submit Button -->

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,86 +1,87 @@
-<h2>Sign up</h2>
+<h2 class="text-center mb-4">Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="d-flex justify-content-center">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "w-50" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <!-- First Name -->
-  <div class="field">
-    <%= f.label :first_name %> <span style="color: red;">*</span><br />
-    <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true %>
-    <small style="color: red;">First name is a required field</small>
-  </div>
-  
-  <!-- Last Name -->
-  <div class="field">
-    <%= f.label :last_name %> <span style="color: red;">*</span><br />
-    <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true %>
-    <small style="color: red;">Last name is a required field</small>
-  </div>
-  
-  <!-- Email -->
-  <div class="field">
-    <%= f.label :email %> <span style="color: red;">*</span><br />
-    <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true %>
-    <small style="color: red;">Email is a required field</small>
-  </div>  
+    <!-- First Name -->
+    <div class="mb-3">
+      <%= f.label :first_name, class: "form-label" %>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control" %>
+      <small class="text-danger">First name is a required field</small>
+    </div>
+    
+    <!-- Last Name -->
+    <div class="mb-3">
+      <%= f.label :last_name, class: "form-label" %>
+      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control" %>
+      <small class="text-danger">Last name is a required field</small>
+    </div>
+    
+    <!-- Email -->
+    <div class="mb-3">
+      <%= f.label :email, class: "form-label" %>
+      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+      <small class="text-danger">Email is a required field</small>
+    </div>  
 
-  <!-- Password -->
-<div class="field">
-  <%= f.label :password %> <span style="color: red;">*</span>
-  <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-  <% end %><br />
-  <%= f.password_field :password, autocomplete: "new-password", required: true %>
-  <small style="color: red;">Password is a required field</small>
+    <!-- Password -->
+    <div class="mb-3">
+      <%= f.label :password, class: "form-label" %>
+      <% if @minimum_password_length %>
+        <em class="text-muted">(Minimum <%= @minimum_password_length %> characters)</em>
+      <% end %><br />
+      <%= f.password_field :password, autocomplete: "new-password", required: true, class: "form-control" %>
+      <small class="text-danger">Password is a required field</small>
+    </div>
+
+    <!-- Password Confirmation -->
+    <div class="mb-3">
+      <%= f.label :password_confirmation, class: "form-label" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "form-control" %>
+      <small class="text-danger">Password confirmation is a required field</small>
+    </div>
+
+    <!-- Phone Number -->
+    <div class="mb-3">
+      <%= f.label :phone_number, class: "form-label" %>
+      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control" %>
+      <small class="text-danger">Phone number is a required field</small>
+    </div>
+
+    <!-- Gender -->
+    <div class="mb-3">
+      <%= f.label :gender, class: "form-label" %>
+      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select" %>
+      <small class="text-danger">Gender is a required field</small>
+    </div>
+
+    <!-- Age Range -->
+    <div class="mb-3">
+      <%= f.label :age_range, class: "form-label" %>
+      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select" %>
+      <small class="text-danger">Age range is a required field</small>
+    </div>
+
+    <!-- Ethnicity -->
+    <div class="mb-3">
+      <%= f.label :ethnicity, class: "form-label" %>
+      <%= f.select :ethnicity, options_for_select([
+        ["White", "White"],
+        ["Black or African American", "Black or African American"],
+        ["Asian", "Asian"],
+        ["American Indian or Alaska Native", "American Indian or Alaska Native"],
+        ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
+        ["Hispanic or Latino", "Hispanic or Latino"],
+        ["Other", "Other"],
+        ["Prefer not to say", "Prefer not to say"]
+      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select" %>
+      <small class="text-danger">Ethnicity is a required field</small>
+    </div>
+
+    <!-- Submit Button -->
+    <div class="mb-3 text-center">
+      <%= f.submit "Sign up", class: "btn btn-primary px-4" %>
+    </div>
+  <% end %>
 </div>
-
-<!-- Password Confirmation -->
-<div class="field">
-  <%= f.label :password_confirmation %> <span style="color: red;">*</span><br />
-  <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true %>
-  <small style="color: red;">Password confirmation is a required field</small>
-</div>
-
-<!-- Phone Number -->
-<div class="field">
-  <%= f.label :phone_number %> <span style="color: red;">*</span><br />
-  <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true %>
-  <small style="color: red;">Phone number is a required field</small>
-</div>
-
-<!-- Gender -->
-<div class="field">
-  <%= f.label :gender %> <span style="color: red;">*</span><br />
-  <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true %>
-  <small style="color: red;">Gender is a required field</small>
-</div>
-
-<!-- Age Range -->
-<div class="field">
-  <%= f.label :age_range %> <span style="color: red;">*</span><br />
-  <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true %>
-  <small style="color: red;">Age range is a required field</small>
-</div>
-
-<!-- Ethnicity -->
-<div class="field">
-  <%= f.label :ethnicity %> <span style="color: red;">*</span><br />
-  <%= f.select :ethnicity, options_for_select([
-    ["White", "White"],
-    ["Black or African American", "Black or African American"],
-    ["Asian", "Asian"],
-    ["American Indian or Alaska Native", "American Indian or Alaska Native"],
-    ["Native Hawaiian or Other Pacific Islander", "Native Hawaiian or Other Pacific Islander"],
-    ["Hispanic or Latino", "Hispanic or Latino"],
-    ["Other", "Other"],
-    ["Prefer not to say", "Prefer not to say"]
-  ]), { prompt: "Select Ethnicity" }, required: true %>
-  <small style="color: red;">Ethnicity is a required field</small>
-</div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,8 +1,8 @@
-<h2 class="text-center mb-4">Sign up</h2>
-
 <div class="d-flex justify-content-center">
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "w-50" }) do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "w-50 form-container", style: "border: 2px solid #808080; padding: 20px; border-radius: 5px;" }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
+
+    <h2 class="text-center mb-4">Sign up</h2>
 
     <!-- First Name -->
     <div class="mb-3">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,21 +7,21 @@
     <!-- First Name -->
     <div class="mb-3">
       <%= f.label :first_name, class: "form-label" %>
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control" %>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", placeholder: "Enter your first name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">First name is a required field</small>
     </div>
     
     <!-- Last Name -->
     <div class="mb-3">
       <%= f.label :last_name, class: "form-label" %>
-      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control" %>
+      <%= f.text_field :last_name, autocomplete: "last_name", placeholder: "Enter your last name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Last name is a required field</small>
     </div>
     
     <!-- Email -->
     <div class="mb-3">
       <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+      <%= f.email_field :email, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Email is a required field</small>
     </div>  
 
@@ -31,35 +31,35 @@
       <% if @minimum_password_length %>
         <em class="text-muted">(Minimum <%= @minimum_password_length %> characters)</em>
       <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password", required: true, class: "form-control" %>
+      <%= f.password_field :password, autocomplete: "new-password", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Password is a required field</small>
     </div>
 
     <!-- Password Confirmation -->
     <div class="mb-3">
       <%= f.label :password_confirmation, class: "form-label" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "form-control" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Password confirmation is a required field</small>
     </div>
 
     <!-- Phone Number -->
     <div class="mb-3">
       <%= f.label :phone_number, class: "form-label" %>
-      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control" %>
+      <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Phone number is a required field</small>
     </div>
 
     <!-- Gender -->
     <div class="mb-3">
       <%= f.label :gender, class: "form-label" %>
-      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select" %>
+      <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Gender is a required field</small>
     </div>
 
     <!-- Age Range -->
     <div class="mb-3">
       <%= f.label :age_range, class: "form-label" %>
-      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select" %>
+      <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Age range is a required field</small>
     </div>
 
@@ -75,7 +75,7 @@
         ["Hispanic or Latino", "Hispanic or Latino"],
         ["Other", "Other"],
         ["Prefer not to say", "Prefer not to say"]
-      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select" %>
+      ]), { prompt: "Select Ethnicity" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Ethnicity is a required field</small>
     </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,12 +7,12 @@
     <!-- First and Last Name on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-6">
-        <%= f.label :first_name, class: "form-label" %>
+        <%= f.label :first_name, class: "form-label" %><span style="color: red;">*</span>
         <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">First name is a required field</small>
       </div>
       <div class="col-md-6">
-        <%= f.label :last_name, class: "form-label" %>
+        <%= f.label :last_name, class: "form-label" %><span style="color: red;">*</span>
         <%= f.text_field :last_name, autocomplete: "last_name", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Last name is a required field</small>
       </div>
@@ -21,12 +21,12 @@
     <!-- Email and Phone Number on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-6">
-        <%= f.label :email, class: "form-label" %>
+        <%= f.label :email, class: "form-label" %><span style="color: red;">*</span>
         <%= f.email_field :email, autocomplete: "email", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Email is a required field</small>
       </div>
       <div class="col-md-6">
-        <%= f.label :phone_number, class: "form-label" %>
+        <%= f.label :phone_number, class: "form-label" %><span style="color: red;">*</span>
         <%= f.text_field :phone_number, placeholder: "e.g., +1 (123) 456-7890", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Phone number is a required field</small>
       </div>
@@ -34,7 +34,7 @@
 
     <!-- Password -->
     <div class="mb-3">
-      <%= f.label :password, class: "form-label" %>
+      <%= f.label :password, class: "form-label" %><span style="color: red;">*</span>
       <% if @minimum_password_length %>
         <em class="text-muted">(Minimum <%= @minimum_password_length %> characters)</em>
       <% end %><br />
@@ -44,7 +44,7 @@
 
     <!-- Password Confirmation -->
     <div class="mb-3">
-      <%= f.label :password_confirmation, class: "form-label" %>
+      <%= f.label :password_confirmation, class: "form-label" %><span style="color: red;">*</span>
       <%= f.password_field :password_confirmation, autocomplete: "new-password", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
       <small class="text-danger">Password confirmation is a required field</small>
     </div>
@@ -52,17 +52,17 @@
     <!-- Gender, Age Range, and Ethnicity on the Same Line -->
     <div class="row mb-3">
       <div class="col-md-4">
-        <%= f.label :gender, class: "form-label" %>
+        <%= f.label :gender, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :gender, options_for_select([["Male", "Male"], ["Female", "Female"]]), { prompt: "Select Gender" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Gender is a required field</small>
       </div>
       <div class="col-md-4">
-        <%= f.label :age_range, class: "form-label" %>
+        <%= f.label :age_range, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :age_range, options_for_select([["18-25", "18-25"], ["26-35", "26-35"], ["36-45", "36-45"], ["46-55", "46-55"], ["56+", "56+"]]), { prompt: "Select Age Range" }, required: true, class: "form-select", style: "background-color: #f0f0f0;" %>
         <small class="text-danger">Age range is a required field</small>
       </div>
       <div class="col-md-4">
-        <%= f.label :ethnicity, class: "form-label" %>
+        <%= f.label :ethnicity, class: "form-label" %><span style="color: red;">*</span>
         <%= f.select :ethnicity, options_for_select([
           ["White", "White"],
           ["Black or African American", "Black or African American"],

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -81,7 +81,7 @@
 
     <!-- Submit Button -->
     <div class="mb-3 text-center">
-      <%= f.submit "Sign up", class: "btn btn-primary px-4" %>
+      <%= f.submit "Sign up", class: "btn btn-secondary text-white px-4" %>
     </div>
   <% end %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,19 +1,17 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "w-25 mx-auto form-container", style: "border: 2px solid #808080; padding: 15px; border-radius: 5px;" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <h2 class="text-center mb-4">Sign in here or sign up below.</h2>
+  <h2 class="text-center mb-4">Sign in</h2>
 
   <!-- Email -->
   <div class="mb-3">
-    <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email address*", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 
   <!-- Password -->
   <div class="mb-3">
-    <%= f.label :password, class: "form-label" %>
-    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Password*", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Password is a required field</small>
   </div>
 
@@ -27,7 +25,7 @@
 
   <!-- Submit Button -->
   <div class="mb-3 text-center">
-    <%= f.submit "Log in", class: "btn btn-secondary text-white px-4" %>
+    <%= f.submit "Sign in", class: "btn btn-secondary text-white px-4" %>
   </div>
 
   <!-- Centered Links (Inside the border) -->

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,14 +6,14 @@
   <!-- Email -->
   <div class="mb-3">
     <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #ffffff;" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 
   <!-- Password -->
   <div class="mb-3">
     <%= f.label :password, class: "form-label" %>
-    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control", style: "background-color: #ffffff;" %>
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control", style: "background-color: #f0f0f0;" %>
     <small class="text-danger">Password is a required field</small>
   </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,37 @@
-<h2>Log in</h2>
+<h2 class="text-center mb-4">Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "w-50 mx-auto" }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <!-- Email -->
+  <div class="mb-3">
+    <%= f.label :email, class: "form-label" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+    <small class="text-danger">Email is a required field</small>
   </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+  <!-- Password -->
+  <div class="mb-3">
+    <%= f.label :password, class: "form-label" %>
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control" %>
+    <small class="text-danger">Password is a required field</small>
   </div>
 
   <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+    <!-- Remember Me -->
+    <div class="form-check mb-3">
+      <%= f.check_box :remember_me, class: "form-check-input", id: "remember_me" %>
+      <%= f.label :remember_me, class: "form-check-label", for: "remember_me" %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+  <!-- Submit Button -->
+  <div class="mb-3 text-center">
+    <%= f.submit "Log in", class: "btn btn-primary px-4" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<!-- Centered Links -->
+<div class="text-center">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
-<h2 class="text-center mb-4">Sign in here or sign up below.</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "w-50 mx-auto" }) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "w-25 mx-auto form-container", style: "border: 2px solid #808080; padding: 15px; border-radius: 5px;" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
+
+  <h2 class="text-center mb-4">Sign in here or sign up below.</h2>
 
   <!-- Email -->
   <div class="mb-3">
@@ -29,9 +29,9 @@
   <div class="mb-3 text-center">
     <%= f.submit "Log in", class: "btn btn-secondary text-white px-4" %>
   </div>
-<% end %>
 
-<!-- Centered Links -->
-<div class="text-center">
-  <%= render "devise/shared/links" %>
-</div>
+  <!-- Centered Links (Inside the border) -->
+  <div class="text-center">
+    <%= render "devise/shared/links" %>
+  </div>
+<% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="text-center mb-4">Log in</h2>
+<h2 class="text-center mb-4">Sign in here or sign up below.</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "w-50 mx-auto" }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -6,14 +6,14 @@
   <!-- Email -->
   <div class="mb-3">
     <%= f.label :email, class: "form-label" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", required: true, class: "form-control", style: "background-color: #ffffff;" %>
     <small class="text-danger">Email is a required field</small>
   </div>
 
   <!-- Password -->
   <div class="mb-3">
     <%= f.label :password, class: "form-label" %>
-    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control" %>
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password", required: true, class: "form-control", style: "background-color: #ffffff;" %>
     <small class="text-danger">Password is a required field</small>
   </div>
 
@@ -27,7 +27,7 @@
 
   <!-- Submit Button -->
   <div class="mb-3 text-center">
-    <%= f.submit "Log in", class: "btn btn-primary px-4" %>
+    <%= f.submit "Log in", class: "btn btn-secondary text-white px-4" %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,15 +1,15 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "text-dark text-decoration-underline" %><br />
+  <%= link_to "Sign in", new_session_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-      <span>No account? </span>
+      <span>Don't have an account? </span>
   <%= link_to "Sign up", new_registration_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-      <span>Forgot your password? </span>
-  <%= link_to "Reset password?", new_password_path(resource_name), class: "text-dark text-decoration-underline" %><br />
+      <span>Forgot Your Password? </span>
+  <%= link_to "Reset password", new_password_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,27 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+      <span>No account? </span>
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+      <span>Forgot your password? </span>
+  <%= link_to "Reset password?", new_password_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "text-dark text-decoration-underline" %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "text-dark text-decoration-underline" %><br />
   <% end %>
 <% end %>


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
 Added minimal styling to all necessary Devise user pages for a cleaner and more consistent look.

- **Why are these changes necessary?**
  To improve navigation and enhance the user experience.
---

### **Key Changes (if applicable, delete if not applicable)**

3. **Views:**
   - [ ] Customized sign-in, sign-up, edit account, and forgot password views.

---

### **How to Test**

1. **Testing the Feature:**
   - Ensure the form fields are displayed.

---

### **Screenshots**
Some of the pages worked on:
<img width="494" alt="Screenshot 2025-01-20 at 10 56 10 PM" src="https://github.com/user-attachments/assets/62f9f210-fdd5-4033-8eee-e97d9fe62cfa" />

<img width="436" alt="Screenshot 2025-01-20 at 10 56 34 PM" src="https://github.com/user-attachments/assets/de158588-2a4c-42bb-8980-2d1d4846d8c7" />

<img width="718" alt="Screenshot 2025-01-20 at 10 56 26 PM" src="https://github.com/user-attachments/assets/f6a075b2-7699-4573-a964-e50ab9824b4a" />

---

### **Notes to Reviewers**
- Any styling suggestions.