### PR TITLE
Bug: Clean footer

### DIFF
--- a/app/assets/stylesheets/footer.css
+++ b/app/assets/stylesheets/footer.css
@@ -6,12 +6,15 @@
 
 .footer-custom {
   color: #403f2b; 
-  position: relative;
-  bottom: auto;
+  position: fixed;
+  bottom: 0;
   left: 0;
   width: 100%;
   background-color: #ffffff; 
   z-index: 999;
+}
+.footer-custom a[href^="mailto:"] {
+  color: #403f2b !important; 
 }
 
 .footer-custom a[href^="mailto:"]:hover {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,4 +7,8 @@ class PagesController < ApplicationController
 
   def about
   end
+
+  def partners
+  end
+  
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,5 +10,4 @@ class PagesController < ApplicationController
 
   def partners
   end
-  
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,75 +1,23 @@
-<footer class="row row-cols-1 row-cols-sm-2 row-cols-md-5 py-5 my-5 border-top footer-custom">
-  <div class="col mb-3">
-    <p>© 2025 Amanahrec</p>
-  </div>
-  <div class="col mb-3">
-    <h5>Contact Us</h5>
-    <ul class="nav flex-column">
-      <li class="nav-item mb-2"><a href="mailto:contact@amanahrec.org" class="text-body">contact@amanahrec.org</a></li>
-      <ul class="nav col-md-4 list-unstyled d-flex">
-        <li class="ms-3">
-          <a href="https://www.facebook.com/profile.php?id=61550329167641" role="button">
-            <i class="fab fa-facebook-f fa-lg"></i>
-          </a>
-        </li>
-        <li class="ms-3">
-          <a href="https://www.instagram.com/amanahrec/" role="button">
-            <i class="fab fa-instagram fa-lg"></i>
-          </a>
-        </li>
-        <li class="ms-3">
-          <a href="https://www.tiktok.com/@amanahrec" role="button">
-            <i class="fab fa-tiktok fa-lg"></i>
-          </a>
-        </li>
-      </ul>
-    </ul>
-  </div>
-  <div class="col mb-3">
-    <h5>Amanahrec</h5>
-    <ul class="nav flex-column">
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">About</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">Activities</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">Events</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">Calendar</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">FAQs</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0">Donate</a></li>
-    </ul>
-  </div>
-  <div class="col mb-3">
-    <h5>Our Other Sites</h5>
-    <ul class="nav flex-column">
-      <li class="nav-item mb-2"><a href="https://www.ecojariyah.com/" class="nav-link p-0 ">Eco Jariyah</a></li>
-      <li class="nav-item mb-2"><a href="#" class="nav-link p-0 ">Hiking Hibjabie</a></li>
-    </ul>
-  </div>
-  <div class="col mb-3">
-  <h5>Our Partners</h5>
-  <div class="d-flex flex-wrap gap-3 justify-content-start align-items-center">
-    <a href="https://araha.org/" target="_blank" rel="noopener noreferrer">
-      <img src="https://araha.org/wp-content/uploads/2024/02/araha_logo_orange_bg-removebg-preview.png" 
-           alt="ARAHA" class="img-fluid" style="max-height: 100px;">
-    </a>
-    <a href="https://www.revivingsisterhood.org/" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/v1/56c530d8f8508295e6c5292e/1559093355869-27EH28K65OGSMGHWWEQ2/logo.png?format=500w" 
-           alt="RISE" class="img-fluid" style="max-height: 100px;">
-    </a>
-    <a href="https://www.loppet.org/" target="_blank" rel="noopener noreferrer" id="loppet">
-      <img src="https://www.loppet.org/wp-content/themes/loppet/img/logo-header-4.png" 
-           alt="Loppet" class="img-fluid" style="max-height: 100px;">
-    </a>
-    <a href="https://www.bikemn.org/" target="_blank" rel="noopener noreferrer">
-      <img src="https://www.bikemn.org/wp-content/themes/bikemn-theme/images/bike-mn-logo.png" 
-           alt="BikeMN" class="img-fluid" style="max-height: 100px;">
-    </a>
-    <a href="https://www.paddlebridge.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/v1/5ae8b4477e3c3ace1e2b48c5/9efe95d0-48d4-43ad-a535-36a0f127a8c3/2023+Badge+Sticker+%28Access-Stewardship-Excellence%29+%283+%C3%97+3+in%29+%282%29.png" 
-           alt="Paddle Bridge" class="img-fluid" style="max-height: 100px;">
-    </a>
-    <a href="https://minneapolisboulderingproject.com/" target="_blank" rel="noopener noreferrer">
-      <img src="https://boulderingproject.com/wp-content/themes/sleepify/assets/images/logo--black-sm.svg" 
-           alt="Minneapolis Bouldering Project" class="img-fluid" style="max-height: 100px;">
-    </a>
-  </div>
-</div>
+<footer class="py-3 footer-custom border-top">  
+  <p>© 2025 Amanahrec Project</p>
+  <p><i class="fa-solid fa-envelope"></i> <a href="mailto:hikinghijabie@gmail.com" class="text-body">hikinghijabie@gmail.com</a></p>
+
+  <ul class="nav justify-content-center  pb-3 mb-3">
+    Follow us
+    <li class="ms-3">
+        <a href="https://www.facebook.com/profile.php?id=61550329167641" role="button">
+          <i class="fab fa-facebook-f fa-lg"></i>
+        </a>
+      </li>
+      <li class="ms-3">
+        <a href="https://www.instagram.com/amanahrec/" role="button">
+          <i class="fab fa-instagram fa-lg"></i>
+        </a>
+      </li>
+      <li class="ms-3">
+        <a href="https://www.tiktok.com/@amanahrec" role="button">
+          <i class="fab fa-tiktok fa-lg"></i>
+        </a>
+      </li>
+  </ul>
 </footer>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -11,6 +11,7 @@
       <!-- Navigation Links -->
       <ul class="navbar-nav lead d-flex align-items-center mx-auto">
         <li class="nav-item"><%= link_to "About", pages_about_path, class: "nav-link" %></li>
+        <li class="nav-item"><%= link_to "Our Partners", pages_partners_path, class: "nav-link" %></li>
         <li class="nav-item"><%= link_to "Activities", "#", class: "nav-link" %></li>
         <li class="nav-item"><%= link_to "Events", "#", class: "nav-link" %></li>
         <li class="nav-item"><%= link_to "Calendar", pages_calendar_path,  class: "nav-link" %></li>

--- a/app/views/pages/partners.html.erb
+++ b/app/views/pages/partners.html.erb
@@ -1,0 +1,28 @@
+<h1 >Our Partners</h1>
+  <div class="d-flex flex-wrap gap-3 justify-content-center py-3">
+    <a href="https://araha.org/" target="_blank" rel="noopener noreferrer">
+      <img src="https://araha.org/wp-content/uploads/2024/02/araha_logo_orange_bg-removebg-preview.png" 
+           alt="ARAHA" class="img-fluid" style="max-height: 100px;">
+    </a>
+    <a href="https://www.revivingsisterhood.org/" target="_blank" rel="noopener noreferrer">
+      <img src="https://images.squarespace-cdn.com/content/v1/56c530d8f8508295e6c5292e/1559093355869-27EH28K65OGSMGHWWEQ2/logo.png?format=500w" 
+           alt="RISE" class="img-fluid" style="max-height: 100px;">
+    </a>
+    <a href="https://www.loppet.org/" target="_blank" rel="noopener noreferrer" id="loppet">
+      <img src="https://www.loppet.org/wp-content/themes/loppet/img/logo-header-4.png" 
+           alt="Loppet" class="img-fluid" style="max-height: 100px;">
+    </a>
+    <a href="https://www.bikemn.org/" target="_blank" rel="noopener noreferrer">
+      <img src="https://www.bikemn.org/wp-content/themes/bikemn-theme/images/bike-mn-logo.png" 
+           alt="BikeMN" class="img-fluid" style="max-height: 100px;">
+    </a>
+    <a href="https://www.paddlebridge.com/" target="_blank" rel="noopener noreferrer">
+      <img src="https://images.squarespace-cdn.com/content/v1/5ae8b4477e3c3ace1e2b48c5/9efe95d0-48d4-43ad-a535-36a0f127a8c3/2023+Badge+Sticker+%28Access-Stewardship-Excellence%29+%283+%C3%97+3+in%29+%282%29.png" 
+           alt="Paddle Bridge" class="img-fluid" style="max-height: 100px;">
+    </a>
+    <a href="https://minneapolisboulderingproject.com/" target="_blank" rel="noopener noreferrer">
+      <img src="https://boulderingproject.com/wp-content/themes/sleepify/assets/images/logo--black-sm.svg" 
+           alt="Minneapolis Bouldering Project" class="img-fluid" style="max-height: 100px;">
+    </a>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "pages/home"
   get "pages/about"
   get "pages/calendar"
+  get "pages/partners"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - Cleans the footer leaving just the copyright Amanahrec Project, Email link, and social font awesome icons.
  -  Our Partners was moved to a separate page

- **Why are these changes necessary?**
  - At client's request
---

1. **Expected Behavior:**
   - A cleaner footer with basic information

---

### **Screenshots**
![Footer Updated](https://github.com/user-attachments/assets/e117cf9a-55d7-40d2-a609-95e4a1d6837e)
![Our Partners](https://github.com/user-attachments/assets/05075967-2bf1-413b-b4b4-a914b91924d6)

---

### **Notes to Reviewers**
- Footer is fixed to the bottom of the page, hopefully no content is hidden, but this will need to be tested

