### PR TITLE
Bug: Removed duplicate in the Forgot Your Password page.

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -13,8 +13,7 @@
   </div>
   <!-- Centered Links (Inside the border) -->
   <div class="text-center">
-    <%= render "devise/shared/links" %
-    >
+    <%= render "devise/shared/links" %>
   </div>
 
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,13 +11,10 @@
   <div class="mb-3 text-center">
     <%= f.submit "Continue", class: "btn btn-secondary text-white px-4" %>
   </div>
-
   <!-- Centered Links (Inside the border) -->
   <div class="text-center">
-    <%= render "devise/shared/links" %>
-  <!-- Centered Links (Inside the border) -->
-  <div class="text-center">
-    <%= render "devise/shared/links" %>
+    <%= render "devise/shared/links" %
+    >
   </div>
 
 <% end %>


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - Removed duplication error in the Forgot Your Password page.

- **Why are these changes necessary?**
  -  Remove duplication error and footer was inside the border
---

1. **Expected Behavior:**
   - There should be no duplication and the footer should be at the bottom. 

---

### **Screenshots**
Before 
![image](https://github.com/user-attachments/assets/9b16fab6-e0ac-46c4-a520-9d4e69f54fcc)

After
![image](https://github.com/user-attachments/assets/acc550ec-c85e-40f7-bf22-cbadc7d6ee01)
---

### **Notes to Reviewers**
- Verify the page is has no duplication errors and footer is in its correct location. 
- Take a look at all devise related views to catch any errors
