### PR TITLE
Bug: Activities date

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -56,8 +56,8 @@ class ActivitiesController < ApplicationController
 
       def activity_params
         params.require(:activity).permit(
-          :title, :description, :date, :location,
-          :capacity, :what_to_bring, :rules, :notes, :cost, :duration, images: []
+          :title, :description, :start_date, :end_date, :location,
+          :capacity, :what_to_bring, :rules, :notes, :cost, images: []
         )
       end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -11,5 +11,4 @@ class Activity < ApplicationRecord
           errors.add(:end_date, "can't be earlier than the start date")
         end
       end
-
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,11 +1,7 @@
 class Activity < ApplicationRecord
     has_many_attached :images
 
-    validates :title, presence: true
-    validates :description, presence: true
-    validates :date, presence: true
-    validates :location, presence: true
+    validates :title, :description, :start_date, :end_date, :location, presence: true
     validates :capacity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :cost, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
-    validates :duration, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,4 +4,12 @@ class Activity < ApplicationRecord
     validates :title, :description, :start_date, :end_date, :location, presence: true
     validates :capacity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
     validates :cost, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+
+    validate :end_date_after_start_date
+    def end_date_after_start_date
+        if end_date.present? && start_date.present? && end_date < start_date
+          errors.add(:end_date, "can't be earlier than the start date")
+        end
+      end
+
 end

--- a/app/views/activities/_form.html.erb
+++ b/app/views/activities/_form.html.erb
@@ -22,7 +22,7 @@
 
   <div class="field">
     <%= form.label :date %><span class="required">*</span>
-    <%= form.datetime_local_field :date, value: Time.now, class: "input-field" %>
+    <%= form.datetime_local_field :date, class: "input-field" %>
   </div>
 
   <div class="field">

--- a/app/views/activities/_form.html.erb
+++ b/app/views/activities/_form.html.erb
@@ -21,8 +21,13 @@
   </div>
 
   <div class="field">
-    <%= form.label :date %><span class="required">*</span>
-    <%= form.datetime_local_field :date, class: "input-field" %>
+    <%= form.label :start_date %><span class="required">*</span>
+    <%= form.datetime_local_field :start_date, class: "input-field" %>
+  </div>
+
+    <div class="field">
+    <%= form.label :end_date %><span class="required">*</span>
+    <%= form.datetime_local_field :end_date, class: "input-field" %>
   </div>
 
   <div class="field">
@@ -58,11 +63,6 @@
       step: "0.01", 
       min: "0", 
       placeholder: "Enter the event cost (0 for free)" %>
-  </div>
-
-  <div class="field">
-    <%= form.label :duration, "Duration (in hours)" %><span class="required">*</span>
-    <%= form.number_field :duration, class: "input-field" %>
   </div>
 
   <!-- Image upload section -->

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -17,7 +17,7 @@
               <%= link_to activity.title, activity_path(activity), class: 'text-decoration-none text-primary' %>
             </h5>
             <p class="card-text text-muted">
-              <i class="fa-regular fa-calendar me-2"></i> <%= activity.date.strftime("%B %d, %Y %I:%M %p") %>
+              <i class="fa-regular fa-calendar me-2"></i> <%= activity.start_date.strftime("%B %d, %Y %I:%M %p") %>
             </p>
             <p class="card-text">
               <i class="fa-solid fa-location-dot me-2"></i> <%= activity.location %>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -17,8 +17,10 @@
               <%= link_to activity.title, activity_path(activity), class: 'text-decoration-none text-primary' %>
             </h5>
             <p class="card-text text-muted">
-              <i class="fa-regular fa-calendar me-2"></i> <%= activity.start_date.strftime("%B %d, %Y %I:%M %p") %>
-            </p>
+  <i class="fa-regular fa-calendar me-2"></i> 
+  <%= activity.start_date.strftime("%B %d, %Y") %> 
+  <%= activity.start_date.strftime("%I:%M %p") %> - <%= activity.end_date.strftime("%I:%M %p") %>
+</p>
             <p class="card-text">
               <i class="fa-solid fa-location-dot me-2"></i> <%= activity.location %>
             </p>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -17,8 +17,8 @@
   <!-- Activity Details -->
   <div class="activity-details">
     <p><strong>Description:</strong> <%= @activity.description %></p>
-    <p><strong>Date:</strong> <%= @activity.start_date %></p>
-    <p><strong>Date:</strong> <%= @activity.end_date %></p>
+    <p><strong>Date:</strong>  <%= @activity.start_date.strftime("%B %d, %Y") %> 
+  <%= @activity.start_date.strftime("%I:%M %p") %> - <%= @activity.end_date.strftime("%I:%M %p") %>
     <p><strong>Location:</strong> <%= @activity.location %></p>
     <p><strong>Capacity:</strong> <%= @activity.capacity %></p>
     <p><strong>What to Bring:</strong> <%= @activity.what_to_bring %></p>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -17,14 +17,14 @@
   <!-- Activity Details -->
   <div class="activity-details">
     <p><strong>Description:</strong> <%= @activity.description %></p>
-    <p><strong>Date:</strong> <%= @activity.date %></p>
+    <p><strong>Date:</strong> <%= @activity.start_date %></p>
+    <p><strong>Date:</strong> <%= @activity.end_date %></p>
     <p><strong>Location:</strong> <%= @activity.location %></p>
     <p><strong>Capacity:</strong> <%= @activity.capacity %></p>
     <p><strong>What to Bring:</strong> <%= @activity.what_to_bring %></p>
     <p><strong>Rules:</strong> <%= @activity.rules %></p>
     <p><strong>Notes:</strong> <%= @activity.notes %></p>
     <p><strong>Cost:</strong> <%= number_to_currency(@activity.cost, unit: "$", precision: 2) %></p>
-    <p><strong>Duration:</strong> <%= @activity.duration %> hours</p>
   </div>
 
   <!-- Action Buttons (Edit, Delete, Back) -->

--- a/db/migrate/20250116231438_create_activities.rb
+++ b/db/migrate/20250116231438_create_activities.rb
@@ -3,14 +3,14 @@ class CreateActivities < ActiveRecord::Migration[7.2]
     create_table :activities do |t|
       t.string :title
       t.text :description
-      t.datetime :date
+      t.datetime :start_date
+      t.datetime :end_date
       t.string :location
       t.integer :capacity
       t.text :what_to_bring
       t.text :rules
       t.text :notes
       t.decimal :cost, precision: 8, scale: 2
-      t.integer :duration
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_180455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,29 +45,24 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
   create_table "activities", force: :cascade do |t|
     t.string "title"
     t.text "description"
-    t.datetime "date"
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.string "location"
     t.integer "capacity"
     t.text "what_to_bring"
     t.text "rules"
     t.text "notes"
     t.decimal "cost", precision: 8, scale: 2
-    t.integer "duration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "early_access_for_members"
-    t.integer "early_access_days"
-    t.datetime "general_registration_start"
-    t.string "recurrence_pattern"
-    t.string "recurrence_days"
-    t.time "recurrence_time"
   end
 
-  create_table "activities_users", id: false, force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "activity_id", null: false
-    t.index ["activity_id", "user_id"], name: "index_activities_users_on_activity_id_and_user_id"
-    t.index ["user_id", "activity_id"], name: "index_activities_users_on_user_id_and_activity_id"
+  create_table "boards", force: :cascade do |t|
+    t.string "name"
+    t.string "position"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "events", force: :cascade do |t|
@@ -85,13 +80,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
     t.boolean "early_access_for_members", default: false, null: false
     t.integer "early_access_days"
     t.datetime "general_registration_start"
-  end
-
-  create_table "events_users", id: false, force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "event_id", null: false
-    t.index ["event_id", "user_id"], name: "index_events_users_on_event_id_and_user_id"
-    t.index ["user_id", "event_id"], name: "index_events_users_on_user_id_and_event_id"
   end
 
   create_table "media", force: :cascade do |t|
@@ -118,6 +106,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.string "status"
+    t.string "stripe_customer_id"
+    t.string "stripe_subscription_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_memberships_on_user_id"
@@ -136,6 +126,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
     t.datetime "updated_at", null: false
     t.index ["paymentable_type", "paymentable_id"], name: "index_payments_on_paymentable"
     t.index ["user_id"], name: "index_payments_on_user_id"
+  end
+
+  create_table "registrations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "registrable_type", null: false
+    t.bigint "registrable_id", null: false
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["registrable_type", "registrable_id"], name: "index_registrations_on_registrable"
+    t.index ["user_id"], name: "index_registrations_on_user_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -178,6 +179,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_182311) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "memberships", "users"
   add_foreign_key "payments", "users"
+  add_foreign_key "registrations", "users"
   add_foreign_key "testimonials", "users"
   add_foreign_key "users", "roles"
 end


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - Cleaned up activities model to user `start_date` and `end_date` to reflect example activities client provided

- **Why are these changes necessary?**
  - Users will see both the start and end times of the activity in the show and index page
---

### **Key Changes (if applicable, delete if not applicable)**
1. **Models:**
   - [ ] Condensed validations into one line, added `:start_date` and `:end_date`
   - [ ] Migration was modified to included  `:start_date` and `:end_date`

2. **Controllers:**
   - [ ] Updated with `:start_date` and `:end_date`

3. **Views:**
   - [ ] All views were modified to use `:start_date` and `:end_date`

---

### **How to Test**
1. **Setup:**
   - [ ] Run rails db:migrate:down VERSION = (Create activities Migration ID). You can get this running `rails db:migrate:status`. Don't need to modify anything. The schema just needs to be updated 
   - [ ] Run migrations: `rails db:migrate`

2. **Testing the Feature:**
   - Create activities including the start and end date. 

3. **Expected Behavior:**
   - The index and show page will show a format like January 21, 2023 10:00 AM - 12:30 PM
---

### **Screenshots**

![Index After](https://github.com/user-attachments/assets/e89ab446-41aa-4a2f-a825-ba5abdfab676)

![Show After](https://github.com/user-attachments/assets/4d122421-ef02-48ec-b0b4-11cd6185f330)
---

### **Notes to Reviewers**
- Make note of the calendar and how that will be impacted. Start and end dates would need to replace just dates
- Create an activity to test
---

### **Related Issues**

