### PR TITLE
Bug: Show membership subscription active date

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -11,7 +11,7 @@ class Membership < ApplicationRecord
     update!(
       status: MEMBERSHIP_STATUS_ACTIVE,
       start_date: Time.now,
-      end_date: nil, 
+      end_date: nil,
       stripe_customer_id: customer.id,
       stripe_subscription_id: subscription.id
     )

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,14 +4,14 @@ class Membership < ApplicationRecord
   MEMBERSHIP_STATUS_ACTIVE = "active".freeze
 
   def active?
-    status == "active" && end_date > Time.now
+    status == "active"
   end
 
   def activate!(customer, subscription)
     update!(
       status: MEMBERSHIP_STATUS_ACTIVE,
       start_date: Time.now,
-      end_date: Time.now + 1.month,
+      end_date: nil, 
       stripe_customer_id: customer.id,
       stripe_subscription_id: subscription.id
     )

--- a/app/services/subscription_cancellation_service.rb
+++ b/app/services/subscription_cancellation_service.rb
@@ -10,11 +10,14 @@ class SubscriptionCancellationService
     stripe_subscription&.cancel
 
     # Update membership status
-    @user.membership.update(status: "canceled")
+    @user.membership.update!(
+    status: "canceled",
+    end_date: Time.now
+  )
 
-    # Update payment status
-    payment = @user.payments.find_by(is_recurring: true, status: "succeeded")
-    payment.update!(status: "canceled") if payment
+  if (payment = @user.payments.find_by(is_recurring: true, status: "succeeded"))
+    payment.update!(status: "canceled")
+  end
 
     true
   rescue Stripe::StripeError => e

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,6 +40,7 @@
         <div>
           <% if current_user.membership&.active? %>
             <button class="btn btn-outline-success" disabled>Active <i class="fas fa-gem"></i></button>
+             since : <%= current_user.membership.start_date.strftime("%m/%d/%Y") %>
           <% else %>
             <button class="btn btn-outline-secondary d-inline" disabled>Inactive <i class="fa-regular fa-gem"></i></button>
             <span>Click "Become a Member!" below to join.</span>


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - Cleans up the membership model to reflect the nature of Stripe's recurring monthly subscriptions, which do not have an automatic end date.

- **Why are these changes necessary?**
  - Clearly inform the user when their subscription started.
---

### **Key Changes**
1. **Models:**
   - Updated `active?` method in the Membership model to exclude `end_date` when the membership is active. 
   - `end_date` is now set to `nil` upon activation unless the membership is canceled.

2. **Service:**
   - Added logic to set `end_date` when the membership is canceled.

3. **Views:**
   - Updated the Devise edit profile view to display **"Active since: [start date]"**.

---

### **How to Test**
1. **Setup:**
   - Ensure your Stripe test environment is configured.
   - Create a new user and subscribe them to a membership.

2. **Testing the Feature:**
   - Check the user's membership status after successful subscription.
   - Cancel the subscription and confirm that `end_date` is set.
   - Re-subscribe the user and verify that `end_date` is `nil`.

3. **Expected Behavior:**
   - When a subscription is active, the profile page should show **"Active since: February 04, 2025"** (formatted as `MM/DD/YYYY`).
   - Upon cancellation, `end_date` should be set.

---

### **Screenshots**
![image](https://github.com/user-attachments/assets/f13b5507-6602-4ebe-a376-4445be85adf0)

---

### **Notes to Reviewers**
- Review the Membership model changes closely to ensure they align with the Stripe subscription logic.
- Consider testing with multiple cancel-and-reactivate scenarios to verify consistency.
