### PR TITLE
Feature: Added date on the stripe checkout for events and activities

### DIFF
--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -75,13 +75,13 @@ class PaymentService
     # Product data for non-Membership types (event, activity)
     def payment_product_data
       return nil if @paymentable.is_a?(Membership) # Membership is handled by product_id
-    
+
       formatted_date = if @paymentable.is_a?(Activity)
                         "#{@paymentable.start_date.strftime('%B %d, %Y %I:%M %p')} - #{@paymentable.end_date.strftime('%I:%M %p')}"
-                      else
+      else
                         "#{@paymentable.start_date.strftime('%B %d, %Y')} - #{@paymentable.end_date.strftime('%B %d, %Y')}"
-                      end
-    
+      end
+
       {
         name: @paymentable.title,
         description: "#{@paymentable.description} | Date: #{formatted_date}"

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -83,8 +83,8 @@ class PaymentService
       end
 
       {
-        name: @paymentable.title,
-        description: "#{@paymentable.description} | Date: #{formatted_date}"
+        name: "#{@paymentable.title} | #{formatted_date}",
+        description: @paymentable.description
       }
     end
 end

--- a/app/services/payment_service.rb
+++ b/app/services/payment_service.rb
@@ -75,6 +75,16 @@ class PaymentService
     # Product data for non-Membership types (event, activity)
     def payment_product_data
       return nil if @paymentable.is_a?(Membership) # Membership is handled by product_id
-      { name: @paymentable.title, description: @paymentable.description }
+    
+      formatted_date = if @paymentable.is_a?(Activity)
+                        "#{@paymentable.start_date.strftime('%B %d, %Y %I:%M %p')} - #{@paymentable.end_date.strftime('%I:%M %p')}"
+                      else
+                        "#{@paymentable.start_date.strftime('%B %d, %Y')} - #{@paymentable.end_date.strftime('%B %d, %Y')}"
+                      end
+    
+      {
+        name: @paymentable.title,
+        description: "#{@paymentable.description} | Date: #{formatted_date}"
+      }
     end
 end


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  -  Adds the date to the payment product data for the Stripe checkout session.
  - Modifies the way event and activity dates are formatted and displayed in the checkout session.

- **Why are these changes necessary?**
  -  Provides more informative details, including the start and end dates for events and activities, in the checkout session.
---

### **Key Changes (if applicable, delete if not applicable)**
1. **Service:**
   - [ ] Updated the payment service to include the date of the event in the description, formatted based on whether the paymentable is an activity or event.
---

### **How to Test**
1. **Testing the Feature:**
   - Register for an event or activity to initiate a Stripe checkout session.

2. **Expected Behavior:**
   - Activities (typically one-day events) will show the date and time range, e.g., "February 4, 2025 10:00 AM - 12:00 PM".
   - Events (spanning multiple days) will show a date range without times, e.g., "February 4, 2025 - February 10, 2025".
---

### **Screenshots**
- Activity
![Activity]!(https://github.com/user-attachments/assets/0de92ff6-e1b1-4e2b-8c7a-f38d312a15bd)
- Event
![Event](https://github.com/user-attachments/assets/c05d7859-5480-4173-9637-d5088cbce4e1)
---

### **Notes to Reviewers**
- Please review the way the date is formatted for both activities and events.
---

### **Known Limitations**
- Images need to be hosted on a publicly accessible server (e.g., AWS S3, Imgur) to obtain a URL for Stripe. This is outside the scope of this change.
- Stripe only allows specific parameters for product_data (like `name`, `description`, and `metadata`).

