### PR TITLE
Centers Month and Year on Calendar

### DIFF
--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,4 +1,5 @@
 <div class="simple-calendar">
+  <div class="calendar-container" style="display: flex; justify-content: center; text-align: center;">
   <div class="calendar-heading">
     <h1 class="calendar-title">
       <%= link_to calendar.url_for_previous_view, class: 'prev-link', style: 'text-decoration: none;' do %>
@@ -14,6 +15,8 @@
       <% end %>
     </h1>
   </div>
+</div>
+
   <div class="calendar-today-container">
     <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view, class: 'today-link' %>
   </div>


### PR DESCRIPTION
### **Description**
- **What does this PR do?**
  - [ ] Centers the calendar month, year and arrows.
---

### **How to Test**
1.  **Testing the Feature:**
   - Navigate to calendar view and check if month and arrows are centered on page.
  
---

### **Screenshots**

<img width="798" alt="Screenshot 2025-02-05 at 11 50 22 AM" src="https://github.com/user-attachments/assets/5194d6ba-4df8-40d6-aac5-d83be034cfff" />

